### PR TITLE
Update readme for uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ have write access to the type of item which is reserved.
   A **response** will look like:
 
   ```json
-    [{"id": "11ae0da2-b605-4d9b-8efb-443e59124479", "name": "Apples",
+    [{"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "name": "Apples",
       "allowed_keys": ["flavor"],
       "items": [{"name": "Macintosh"},
                 {"name": "Granny Smith"}]}]
@@ -55,7 +55,7 @@ have write access to the type of item which is reserved.
    A **success response** will look like:
 
    ```json
-   {"id": "11ae0da2-b605-4d9b-8efb-443e59124479",
+   {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479",
     "start_time": "2016-02-16T15:30:00-05:00",
     "end_time": "2016-02-17T09:45:00-05:00",
     "item_type": "Apples",
@@ -97,7 +97,7 @@ have write access to the type of item which is reserved.
 
   A **response** will look like:
   ```json
-  {"id": "11ae0da2-b605-4d9b-8efb-443e59124479",
+  {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479",
    "start_time": "2016-02-16T15:30:00-05:00",
    "end_time": "2016-02-17T09:45:00-05:00",
    "item_type": "Apples",
@@ -215,6 +215,7 @@ have write access to the type of item which is reserved.
 
   This endpoint allows you to create an item type given a particular name.
   In order to create a new item type, you must have write access to at least one other item type.
+  Creating a new item type will grant write permission to the service that created it.
   You may optionally specify what metadata keys you want other endpoints to be able to configure about items of this type, which should be an array.
   
   For example, your **request** might look like:
@@ -260,7 +261,7 @@ have write access to the type of item which is reserved.
   A **success response** will look like:
 
   ```json
-  {"id": 11ae0da2-b605-4d9b-8efb-443e59124478, "name": "Awesome new couch", "item_type_uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}}
+  {"uuid": 11ae0da2-b605-4d9b-8efb-443e59124478, "name": "Awesome new couch", "item_type_uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}}
   ```
 
   A **failure response** will look like:
@@ -285,8 +286,8 @@ have write access to the type of item which is reserved.
   A **response** will look like:
 
   ```json
-  {[{"id": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Awesome new couch", "item_type_uuid": 11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}},
-    {"id": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Cool leather futon", "item_type_id": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {"texture": "leather"}}]}
+  {[{"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Awesome new couch", "item_type_uuid": 11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}},
+    {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Cool leather futon", "item_type_id": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {"texture": "leather"}}]}
   ```
 
   ---
@@ -298,7 +299,7 @@ have write access to the type of item which is reserved.
   A **response** will look like:
 
   ```json
-  {"id": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Awesome new couch", "item_type_id": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}}
+  {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Awesome new couch", "item_type_id": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}}
   ```
   
   ---

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,8 +18,8 @@ ActiveRecord::Schema.define(version: 20160316175333) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.string   "allowed_keys", limit: 255
-    t.string   "uuid",         limit: 255
     t.integer  "creator_id",   limit: 4
+    t.string   "uuid",         limit: 255
   end
 
   create_table "items", force: :cascade do |t|
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 20160316175333) do
   create_table "permissions", force: :cascade do |t|
     t.boolean  "write",                  default: false
     t.integer  "item_type_id", limit: 4
-    t.integer  "service_id",   limit: 4
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
+    t.integer  "service_id",   limit: 4
   end
 
   create_table "reservations", force: :cascade do |t|


### PR DESCRIPTION
the example for returned json had a slight error, the field named id was in fact named uuid. For example on `GET /item_types/`
` [{"id": "11ae0da2-b605-4d9b-8efb-443e59124479", "name": "Apples",
    "allowed_keys": ["flavor"],
    "items": [{"name": "Macintosh"},
              {"name": "Granny Smith"}]}]` 
versus

` [{"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "name": "Apples",
    "allowed_keys": ["flavor"],
    "items": [{"name": "Macintosh"},
              {"name": "Granny Smith"}]}]`

fixes #22 