### PR TITLE
Introduce serializers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'active_model_serializers'
 gem 'factory_girl_rails'
 gem 'mysql'
 gem 'rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.2)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
     activejob (4.2.5.1)
       activesupport (= 4.2.5.1)
       globalid (>= 0.3.0)
@@ -80,6 +85,11 @@ GEM
       activesupport (>= 4.1.0)
     i18n (0.7.0)
     json (1.8.3)
+    jsonapi (0.1.1.beta6)
+      jsonapi-parser (= 0.1.1.beta3)
+      jsonapi-renderer (= 0.1.1.beta1)
+    jsonapi-parser (0.1.1.beta3)
+    jsonapi-renderer (0.1.1.beta1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -194,6 +204,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   better_errors
   binding_of_caller
   capistrano
@@ -215,4 +226,4 @@ DEPENDENCIES
   umts-custom-cops
 
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ have write access to the type of item which is reserved.
    ```json
    POST /reservations
      {"item_type": "Apples",
-      "start_time": "2016-02-16T15:30:00-05:00",
-      "end_time": "2016-02-17T09:45:00-05:00"}
+      "start_datetime": "2016-02-16T15:30:00-05:00",
+      "end_datetime": "2016-02-17T09:45:00-05:00"}
    ```
 
    If a reservation with those parameters is available, the attributes of the newly created reservation are returned.
@@ -56,8 +56,8 @@ have write access to the type of item which is reserved.
 
    ```json
    {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479",
-    "start_time": "2016-02-16T15:30:00-05:00",
-    "end_time": "2016-02-17T09:45:00-05:00",
+    "start_datetime": "2016-02-16T15:30:00-05:00",
+    "end_datetime": "2016-02-17T09:45:00-05:00",
     "item_type": "Apples",
     "item": "Granny Smith"}
    ```
@@ -78,7 +78,7 @@ have write access to the type of item which is reserved.
 
    ```json
    PUT /reservations/100
-   {"reservation": {"start_time": "2016-02-16T18:00:00-05:00"}}
+   {"reservation": {"start_datetime": "2016-02-16T18:00:00-05:00"}}
    ```
 
    If the change has been successfully applied, the new attributes will be returned.
@@ -98,8 +98,8 @@ have write access to the type of item which is reserved.
   A **response** will look like:
   ```json
   {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479",
-   "start_time": "2016-02-16T15:30:00-05:00",
-   "end_time": "2016-02-17T09:45:00-05:00",
+   "start_datetime": "2016-02-16T15:30:00-05:00",
+   "end_datetime": "2016-02-17T09:45:00-05:00",
    "item_type": "Apples",
    "item": "Granny Smith"}
   ```
@@ -143,23 +143,23 @@ have write access to the type of item which is reserved.
    
    This endpoint returns all of the reservations for a particular item type in a given time range.
    You must have read access to the given item type.
-   The `start_time` and `end_time` arguments must be in ISO 8601 format.
+   The `start_datetime` and `end_datetime` arguments must be in ISO 8601 format.
    Each reservation will list the start and end times in ISO 8601 format.
 
    For instance, your **request** might look like:
    
    ```json
    GET /reservations
-   {"start_time": "2016-02-10T12:00:00-05:00",
-    "end_time": "2016-02-17T12:00:00-05:00",
+   {"start_datetime": "2016-02-10T12:00:00-05:00",
+    "end_datetime": "2016-02-17T12:00:00-05:00",
     "item_type": "Apples"}
    ```
 
    A **response** will look like:
 
    ```json
-   [{"start_time": "2016-02-11T15:45:00-05:00", "end_time": "2016-02-11T21:00:00-05:00"},
-    {"start_time": "2016-02-17T10:30:00-05:00", "end_time": "2016-02-19T21:00:00-05:00"}]
+   [{"start_datetime": "2016-02-11T15:45:00-05:00", "end_datetime": "2016-02-11T21:00:00-05:00"},
+    {"start_datetime": "2016-02-17T10:30:00-05:00", "end_datetime": "2016-02-19T21:00:00-05:00"}]
    ```
    
    ---
@@ -254,13 +254,13 @@ have write access to the type of item which is reserved.
 
   ```json
   POST /items
-  {"name": "Awesome new couch", "item_type_uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "reservable": true}
+  {"name": "Awesome new couch", "item_type": {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479"} , "reservable": true}
   ```
 
   A **success response** will look like:
 
   ```json
-  {"uuid": 11ae0da2-b605-4d9b-8efb-443e59124478, "name": "Awesome new couch", "item_type_uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}}
+  {"uuid": 11ae0da2-b605-4d9b-8efb-443e59124478, "name": "Awesome new couch", "item_type": {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479"}, "data": {}}
   ```
 
   A **failure response** will look like:
@@ -279,14 +279,14 @@ have write access to the type of item which is reserved.
 
   ```json
   GET /items
-  {"item_type_uuid": "11ae0da2-b605-4d9b-8efb-443e59124479"}
+  {"item_type" => "uuid": "11ae0da2-b605-4d9b-8efb-443e59124479"}}
   ```
 
   A **response** will look like:
 
   ```json
-  {[{"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Awesome new couch", "item_type_uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}},
-    {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Cool leather futon", "item_type_uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {"texture": "leather"}}]}
+  {[{"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Awesome new couch", "item_type" {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479"}, "data": {}},
+    {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Cool leather futon", "item_type" {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479"}, "data": {"texture": "leather"}}]}
   ```
 
   ---
@@ -298,7 +298,7 @@ have write access to the type of item which is reserved.
   A **response** will look like:
 
   ```json
-  {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Awesome new couch", "item_type_uuid": "11ae0da2-b605-4d9b-8efb-443e59124479", "data": {}}
+  {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124478", "name": "Awesome new couch", "item_type" {"uuid": "11ae0da2-b605-4d9b-8efb-443e59124479"}, "data": {}}
   ```
   
   ---

--- a/app/controllers/v1/item_types_controller.rb
+++ b/app/controllers/v1/item_types_controller.rb
@@ -7,8 +7,7 @@ module V1
       item_type = ItemType.new params.permit(:name, allowed_keys: [])
                   .merge creator_id: @service.id
       if item_type.save
-        render json: item_type, except: %i(created_at updated_at creator_id id),
-               include: :items # there won't be any
+        render json: item_type
       else render json: { errors: item_type.errors.full_messages },
                   status: :unprocessable_entity
       end
@@ -21,22 +20,19 @@ module V1
     end
 
     def index
-      render json: @service.readable_item_types,
-             except: %i(created_at updated_at id creator_id),
-             include: { items: { only: :name } }
+      render json: @service.readable_item_types
     end
 
     def show
       deny_access! and return unless @service.can_read? @item_type
-      render json: @item_type, except: %i(created_at updated_at id creator_id),
-             include: { items: { only: [:uuid, :name] } }
+      render json: @item_type
     end
 
     def update
       deny_access! and return unless @service.can_write_to? @item_type
       changes = params.require(:item_type).permit(:name, allowed_keys: [])
       if @item_type.update changes
-        render json: @item_type, except: %i(created_at updated_at id creator_id)
+        render json: @item_type
       else render json: { errors: @item_type.errors.full_messages },
                   status: :unprocessable_entity
       end

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -8,7 +8,7 @@ module V1
       item = Item.new params.permit(:name, :reservable, data: {})
              .merge(item_type_id: item_type.id)
       if item.save
-        render json: item, except: %i(created_at updated_at id)
+        render json: item
       else render json: { errors: item.errors.full_messages },
                   status: :unprocessable_entity
       end
@@ -23,12 +23,12 @@ module V1
     def index
       item_type = ItemType.find_by uuid: params.require(:item_type_uuid)
       deny_access! and return unless @service.can_read? item_type
-      render json: item_type.items.order(:name).map(&:external_attributes)
+      render json: item_type.items
     end
 
     def show
       deny_access! and return unless @service.can_read? @item.item_type
-      render json: @item, except: [:created_at, :updated_at]
+      render json: @item
     end
 
     def update
@@ -43,7 +43,7 @@ module V1
         return
       end
       if @item.update changes
-        render json: @item, except: %i(created_at updated_at id)
+        render json: @item
       else render json: { errors: @item.errors.full_messages },
                   status: :unprocessable_entity
       end

--- a/app/controllers/v1/reservations_controller.rb
+++ b/app/controllers/v1/reservations_controller.rb
@@ -26,11 +26,11 @@ module V1
     def index
       start_datetime = DateTime.iso8601 params.require(:start_time)
       end_datetime = DateTime.iso8601 params.require(:end_time)
-      reservations = @item_type.reservations
-                               .during start_datetime, end_datetime
+      reservations = @item_type.reservations.during start_datetime, end_datetime
+      # Render just the start and end datetimes
       reservations = reservations.map do |reservation|
-        { start_time: reservation.start_datetime.iso8601,
-          end_time: reservation.end_datetime.iso8601 }
+        { start_datetime: reservation.start_datetime.iso8601(3),
+          end_datetime: reservation.end_datetime.iso8601(3) }
       end
       render json: reservations
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -33,20 +33,6 @@ class Item < ActiveRecord::Base
                        creator: creator
   end
 
-  def to_json(*_)
-    external_attributes.to_json
-  end
-
-  def external_attributes
-    {
-      uuid: uuid,
-      name: name,
-      reservable: reservable?,
-      item_type_uuid: item_type.uuid,
-      data: data
-    }
-  end
-
   private
 
   def data_allowed_keys

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -17,14 +17,6 @@ class Reservation < ActiveRecord::Base
           end_datetime, start_datetime
   }
 
-  def to_json(*_)
-    { uuid: uuid,
-      start_time: start_datetime.iso8601,
-      end_time: end_datetime.iso8601,
-      item_type: item_type.name,
-      item: item.name }.to_json
-  end
-
   private
 
   def start_time_before_end_time

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,8 @@
+class ItemSerializer < ActiveModel::Serializer
+  belongs_to :item_type
+  attributes :uuid, :name, :reservable, :data
+
+  class ItemTypeSerializer < ActiveModel::Serializer
+    attributes :uuid
+  end
+end

--- a/app/serializers/item_type_serializer.rb
+++ b/app/serializers/item_type_serializer.rb
@@ -1,0 +1,8 @@
+class ItemTypeSerializer < ActiveModel::Serializer
+  has_many :items
+  attributes :uuid, :name, :allowed_keys
+
+  class ItemSerializer < ActiveModel::Serializer
+    attributes :uuid, :name
+  end
+end

--- a/app/serializers/reservation_serializer.rb
+++ b/app/serializers/reservation_serializer.rb
@@ -1,0 +1,13 @@
+class ReservationSerializer < ActiveModel::Serializer
+  belongs_to :item
+  belongs_to :item_type
+  attributes :uuid, :start_datetime, :end_datetime
+
+  class ItemSerializer < ActiveModel::Serializer
+    attributes :name
+  end
+
+  class ItemTypeSerializer < ActiveModel::Serializer
+    attributes :name
+  end
+end

--- a/spec/controllers/v1/item_types_controller_spec.rb
+++ b/spec/controllers/v1/item_types_controller_spec.rb
@@ -113,8 +113,8 @@ describe V1::ItemTypesController do
         [{ 'uuid' => item_type.uuid,
            'name' => item_type.name,
            'allowed_keys' => item_type.allowed_keys.map(&:to_s),
-           'items' => [{ 'name' => item_1.name },
-                       { 'name' => item_2.name }] }])
+           'items' => [{ 'name' => item_1.name, 'uuid' => item_1.uuid },
+                       { 'name' => item_2.name, 'uuid' => item_2.uuid }] }])
     end
   end
 
@@ -178,10 +178,15 @@ describe V1::ItemTypesController do
           end
           it 'responds with the new attributes' do
             submit
-            expect(response.body).to eql(
-              item_type.reload.to_json(except:
-                                       %i(created_at updated_at creator_id id))
-            )
+            item_type.reload
+            json = JSON.parse response.body
+            expect(json).to eql({
+              "uuid" => item_type.uuid,
+              "name" => item_type.name,
+              "allowed_keys" => item_type.allowed_keys.map(&:to_s),
+              "items" => []
+            })
+            
           end
         end
         context 'change not applied successfully' do

--- a/spec/controllers/v1/item_types_controller_spec.rb
+++ b/spec/controllers/v1/item_types_controller_spec.rb
@@ -180,13 +180,11 @@ describe V1::ItemTypesController do
             submit
             item_type.reload
             json = JSON.parse response.body
-            expect(json).to eql({
-              "uuid" => item_type.uuid,
-              "name" => item_type.name,
-              "allowed_keys" => item_type.allowed_keys.map(&:to_s),
-              "items" => []
-            })
-            
+            allowed_keys = item_type.allowed_keys.map(&:to_s)
+            expect(json).to eql('uuid' => item_type.uuid,
+                                'name' => item_type.name,
+                                'allowed_keys' => allowed_keys,
+                                'items' => [])
           end
         end
         context 'change not applied successfully' do

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -170,13 +170,11 @@ describe V1::ItemsController do
             submit
             item.reload
             json = JSON.parse response.body
-            expect(json).to eql({
-              "uuid" => item.uuid,
-              "name" => item.name,
-              "reservable" => item.reservable,
-              "data" => item.data,
-              "item_type" => { "uuid" => item_type.uuid }
-            })
+            expect(json).to eql('uuid' => item.uuid,
+                                'name' => item.name,
+                                'reservable' => item.reservable,
+                                'data' => item.data,
+                                'item_type' => { 'uuid' => item_type.uuid })
           end
         end
         context 'change not applied successfully' do

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -23,7 +23,7 @@ describe V1::ItemsController do
             'uuid' => Item.last.uuid,
             'name' => 'Gillig',
             'reservable' => true,
-            'item_type_uuid' => item_type.uuid,
+            'item_type' => { 'uuid' => item_type.uuid },
             'data' => {})
         end
       end
@@ -95,7 +95,7 @@ describe V1::ItemsController do
           'uuid' => item.uuid,
           'name' => item.name,
           'reservable' => item.reservable,
-          'item_type_uuid' => item.item_type.uuid,
+          'item_type' => { 'uuid' => item.item_type.uuid },
           'data' => item.data }]
       end
     end
@@ -121,7 +121,7 @@ describe V1::ItemsController do
             'uuid' => item.uuid,
             'name' => item.name,
             'reservable' => item.reservable,
-            'item_type_uuid' => item.item_type.uuid,
+            'item_type' => { 'uuid' => item.item_type.uuid },
             'data' => item.data)
         end
       end
@@ -168,9 +168,15 @@ describe V1::ItemsController do
           end
           it 'responds with the new attributes' do
             submit
-            expect(response.body).to eql(
-              item.reload.to_json(except: %i(created_at updated_at))
-            )
+            item.reload
+            json = JSON.parse response.body
+            expect(json).to eql({
+              "uuid" => item.uuid,
+              "name" => item.name,
+              "reservable" => item.reservable,
+              "data" => item.data,
+              "item_type" => { "uuid" => item_type.uuid }
+            })
           end
         end
         context 'change not applied successfully' do

--- a/spec/controllers/v1/reservations_controller_spec.rb
+++ b/spec/controllers/v1/reservations_controller_spec.rb
@@ -41,13 +41,13 @@ describe V1::ReservationsController do
       it 'responds with the created reservation' do
         submit
         json = JSON.parse response.body
-        expect(json).to eql({
-          "uuid" => reservation.uuid,
-          "start_datetime" => reservation.start_datetime.iso8601(3),
-          "end_datetime" => reservation.end_datetime.iso8601(3),
-          "item" => { "name" => item.name },
-          "item_type" => { "name" => item_type.name }
-        })
+        expect(json).to eql(
+          'uuid' => reservation.uuid,
+          'start_datetime' => reservation.start_datetime.iso8601(3),
+          'end_datetime' => reservation.end_datetime.iso8601(3),
+          'item' => { 'name' => item.name },
+          'item_type' => { 'name' => item_type.name }
+        )
       end
     end
     context 'with no available item' do
@@ -123,10 +123,10 @@ describe V1::ReservationsController do
         it 'includes the ISO 8601 start and end times of the reservation' do
           submit
           json = JSON.parse response.body
-          expect(json).to eql([{
-            'start_datetime' => reservation.start_datetime.iso8601(3),
-            'end_datetime' => reservation.end_datetime.iso8601(3)
-          }])
+          expect(json).to eql(
+            [{ 'start_datetime' => reservation.start_datetime.iso8601(3),
+               'end_datetime' => reservation.end_datetime.iso8601(3) }]
+          )
         end
       end
       context 'no read access to item type' do
@@ -160,13 +160,13 @@ describe V1::ReservationsController do
         it 'responds with the found reservation' do
           submit
           json = JSON.parse response.body
-          expect(json).to eql({
-            "uuid" => reservation.uuid,
-            "start_datetime" => reservation.start_datetime.iso8601(3),
-            "end_datetime" => reservation.end_datetime.iso8601(3),
-            "item" => { "name" => reservation.item.name },
-            "item_type" => { "name" => reservation.item_type.name }
-          })
+          expect(json).to eql(
+            'uuid' => reservation.uuid,
+            'start_datetime' => reservation.start_datetime.iso8601(3),
+            'end_datetime' => reservation.end_datetime.iso8601(3),
+            'item' => { 'name' => reservation.item.name },
+            'item_type' => { 'name' => reservation.item_type.name }
+          )
         end
       end
       context 'as an unrelated service' do
@@ -223,13 +223,13 @@ describe V1::ReservationsController do
           submit
           json = JSON.parse response.body
           reservation.reload
-          expect(json).to eql({
-            "uuid" => reservation.uuid,
-            "start_datetime" => reservation.start_datetime.iso8601(3),
-            "end_datetime" => reservation.end_datetime.iso8601(3),
-            "item" => { "name" => reservation.item.name },
-            "item_type" => { "name" => reservation.item_type.name }
-          })
+          expect(json).to eql(
+            'uuid' => reservation.uuid,
+            'start_datetime' => reservation.start_datetime.iso8601(3),
+            'end_datetime' => reservation.end_datetime.iso8601(3),
+            'item' => { 'name' => reservation.item.name },
+            'item_type' => { 'name' => reservation.item_type.name }
+          )
         end
       end
       context 'change not applied successfully' do

--- a/spec/controllers/v1/reservations_controller_spec.rb
+++ b/spec/controllers/v1/reservations_controller_spec.rb
@@ -40,7 +40,14 @@ describe V1::ReservationsController do
       end
       it 'responds with the created reservation' do
         submit
-        expect(response.body).to eql reservation.to_json
+        json = JSON.parse response.body
+        expect(json).to eql({
+          "uuid" => reservation.uuid,
+          "start_datetime" => reservation.start_datetime.iso8601(3),
+          "end_datetime" => reservation.end_datetime.iso8601(3),
+          "item" => { "name" => item.name },
+          "item_type" => { "name" => item_type.name }
+        })
       end
     end
     context 'with no available item' do
@@ -116,9 +123,10 @@ describe V1::ReservationsController do
         it 'includes the ISO 8601 start and end times of the reservation' do
           submit
           json = JSON.parse response.body
-          expect(json).to include
-          { 'start_time' => reservation.start_datetime.iso8601,
-            'end_time' => reservation.end_datetime.iso8601 }
+          expect(json).to eql([{
+            'start_datetime' => reservation.start_datetime.iso8601(3),
+            'end_datetime' => reservation.end_datetime.iso8601(3)
+          }])
         end
       end
       context 'no read access to item type' do
@@ -151,7 +159,14 @@ describe V1::ReservationsController do
         end
         it 'responds with the found reservation' do
           submit
-          expect(response.body).to eql reservation.to_json
+          json = JSON.parse response.body
+          expect(json).to eql({
+            "uuid" => reservation.uuid,
+            "start_datetime" => reservation.start_datetime.iso8601(3),
+            "end_datetime" => reservation.end_datetime.iso8601(3),
+            "item" => { "name" => reservation.item.name },
+            "item_type" => { "name" => reservation.item_type.name }
+          })
         end
       end
       context 'as an unrelated service' do
@@ -206,7 +221,15 @@ describe V1::ReservationsController do
         end
         it 'responds with the new attributes' do
           submit
-          expect(response.body).to eql reservation.to_json
+          json = JSON.parse response.body
+          reservation.reload
+          expect(json).to eql({
+            "uuid" => reservation.uuid,
+            "start_datetime" => reservation.start_datetime.iso8601(3),
+            "end_datetime" => reservation.end_datetime.iso8601(3),
+            "item" => { "name" => reservation.item.name },
+            "item_type" => { "name" => reservation.item_type.name }
+          })
         end
       end
       context 'change not applied successfully' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ def deauthenticate!
 end
 
 def default_start_time
-  Date.yesterday.to_datetime
+  Date.yesterday.to_datetime.change usec: 0
 end
 
 # By default reservations are 2 days in length


### PR DESCRIPTION
Some changes:

+ ISO 8601 times now all include milliseconds.
+ Reservations now include `start_datetime` and `end_datetime` rather
than `start_time` and `end_time`.
+ Items now include a nested `item_type` object with a `uuid` attribute,
rather than a single `item_type_uuid` attribute.

Closes #34.